### PR TITLE
Added configuration for track files. By default, behavior should rema…

### DIFF
--- a/Sources/BandcampDownloader/Business Objects/Track.cs
+++ b/Sources/BandcampDownloader/Business Objects/Track.cs
@@ -7,8 +7,12 @@ namespace BandcampDownloader {
         public int    Number { get; set; }
         public String Mp3Url { get; set; }
 
-        public String GetFileName(String artist) {
-            String fileName = Number.ToString("00") + " " + artist + " - " + Title + ".mp3";
+        public String GetFileName(String artist)
+        {
+            String fileName =
+                UserSettings.FilenameFormat.Replace("{artist}", artist)
+                    .Replace("{title}", Title)
+                    .Replace("{tracknum}", Number.ToString("00"));
             return fileName.ToAllowedFileName();
         }
     }

--- a/Sources/BandcampDownloader/Helpers/BandcampHelper.cs
+++ b/Sources/BandcampDownloader/Helpers/BandcampHelper.cs
@@ -27,7 +27,12 @@ namespace BandcampDownloader {
             // Deserialize JSON
             Album album;
             try {
-                album = JsonConvert.DeserializeObject<JsonAlbum>(albumData).ToAlbum();
+                var settings = new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Ignore,
+                    MissingMemberHandling = MissingMemberHandling.Ignore
+                };
+                album = JsonConvert.DeserializeObject<JsonAlbum>(albumData, settings).ToAlbum();
             } catch (Exception e) {
                 throw new Exception("Could not deserialize JSON data.", e);
             }

--- a/Sources/BandcampDownloader/Miscellaneous/UserSettings.cs
+++ b/Sources/BandcampDownloader/Miscellaneous/UserSettings.cs
@@ -26,6 +26,8 @@ namespace BandcampDownloader {
         public static double DownloadRetryExponential { get; set; }
         [JsonProperty]
         public static double AllowableFileSizeDifference { get; set; }
+        [JsonProperty]
+        public static String FilenameFormat { get; set; }
 
         /// <summary>
         ///  Creates a new UserSettings with default values.
@@ -67,6 +69,7 @@ namespace BandcampDownloader {
             DownloadRetryCooldown = 0;
             DownloadRetryExponential = 1;
             AllowableFileSizeDifference = 0.05;
+            FilenameFormat = "{tracknum} {artist} - {title}.mp3";//Number.ToString("00") + " " + artist + " - " + Title + ".mp3";
         }
 
         /// <summary>


### PR DESCRIPTION
Added configuration for track files. By default, behavior should remain the same. However, one can edit the "FilenameFormat" string in the settings file to use {title}, {tracknum}, and {artist} for their respective values. Don't forget to have ".mp3" at the end of the string!