### PR TITLE
fix: make discography retrieval logic more robust

### DIFF
--- a/src/BandcampDownloader/Core/DownloadManager.cs
+++ b/src/BandcampDownloader/Core/DownloadManager.cs
@@ -465,19 +465,16 @@ namespace BandcampDownloader {
                     }
                 }
 
-                // Get albums referred on the page
-                regex = new Regex("TralbumData.*\n.*url:.*'/music'\n");
-                if (!regex.IsMatch(htmlCode)) {
-                    // This seem to be a one-album artist with no "music" page => URL redirects to the unique album URL
+                var count = albumsUrls.Count;
+                try {
+                    // We are on a real "music" page if we 
+                    albumsUrls.AddRange(BandcampHelper.GetAlbumsUrl(htmlCode));
+                } catch (NoAlbumFoundException) {
+                    LogAdded(this, new LogArgs($"No referred album could be found on {artistMusicPage}. Try to uncheck the \"Download artist discography\" option", LogType.Error));
+                }
+                // This seem to be a one-album artist with no "music" page => URL redirects to the unique album URL
+                if(albumsUrls.Count - count == 0) {
                     albumsUrls.Add(url);
-                } else {
-                    // We are on a real "music" page
-                    try {
-                        albumsUrls.AddRange(BandcampHelper.GetAlbumsUrl(htmlCode));
-                    } catch (NoAlbumFoundException) {
-                        LogAdded(this, new LogArgs($"No referred album could be found on {artistMusicPage}. Try to uncheck the \"Download artist discography\" option", LogType.Error));
-                        continue;
-                    }
                 }
             }
 


### PR DESCRIPTION
This change makes it possible to get discography for a links such as `https://tympanikaudio.bandcamp.com/`.