### PR TITLE
Added fix for singles missing release_date resulting in "1" set as year

### DIFF
--- a/src/BandcampDownloader/Model/JSON/JsonAlbum.cs
+++ b/src/BandcampDownloader/Model/JSON/JsonAlbum.cs
@@ -28,6 +28,13 @@ namespace BandcampDownloader {
             // Some albums do not have a cover art
             string artworkUrl = ArtId == null ? null : _urlStart + ArtId.PadLeft(10, '0') + _urlEnd;
 
+            // Singles might not have release date filled
+            
+            if (ReleaseDate == new DateTime())
+            {
+                ReleaseDate = AlbumData.ReleaseDate;
+            }
+
             var album = new Album(Artist, artworkUrl, ReleaseDate, AlbumData.AlbumTitle);
 
             // Some tracks do not have their URL filled on some albums (pre-release...)

--- a/src/BandcampDownloader/Model/JSON/JsonAlbumData.cs
+++ b/src/BandcampDownloader/Model/JSON/JsonAlbumData.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace BandcampDownloader {
 

--- a/src/BandcampDownloader/Model/JSON/JsonAlbumData.cs
+++ b/src/BandcampDownloader/Model/JSON/JsonAlbumData.cs
@@ -6,5 +6,8 @@ namespace BandcampDownloader {
 
         [JsonProperty("title")]
         public string AlbumTitle { get; set; }
+
+        [JsonProperty("release_date")]
+        public DateTime ReleaseDate { get; set; }
     }
 }


### PR DESCRIPTION
Bug itself is fully described here:
https://github.com/Otiel/BandcampDownloader/issues/144

This pull request provides quick fix, adds check if album_release_date is set in album json. If it's not, than we try to take it from current -> release_date.