### PR TITLE
[fixes #185] Workaround of URL spoofing for this program.

### DIFF
--- a/src/BandcampDownloader/Core/DownloadManager.cs
+++ b/src/BandcampDownloader/Core/DownloadManager.cs
@@ -341,6 +341,8 @@ namespace BandcampDownloader
                     // Start download
                     try
                     {
+                        //Workaround of URL spoofing for this program.
+                        album.ArtworkUrl = album.ArtworkUrl.Replace("https", "http");
                         await webClient.DownloadFileTaskAsync(album.ArtworkUrl, album.ArtworkTempPath);
                         artworkDownloaded = true;
                     }

--- a/src/BandcampDownloader/Helpers/FileHelper.cs
+++ b/src/BandcampDownloader/Helpers/FileHelper.cs
@@ -36,6 +36,8 @@ namespace BandcampDownloader
         /// <returns>The size of the file located at the provided URL.</returns>
         public static async Task<long> GetFileSizeAsync(string url, string protocolMethod)
         {
+            //Workaround of URL spoofing for this program.
+            url = url.Replace("https", "http");
             var webRequest = HttpWebRequest.Create(url);
             webRequest.Method = protocolMethod;
             long fileSize;

--- a/src/BandcampDownloader/Properties/AssemblyInfo.cs
+++ b/src/BandcampDownloader/Properties/AssemblyInfo.cs
@@ -47,6 +47,6 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.5")]
-[assembly: AssemblyFileVersion("1.3.5")]
+[assembly: AssemblyVersion("1.3.6")]
+[assembly: AssemblyFileVersion("1.3.6")]
 [assembly: GuidAttribute("8C171C7F-9BAC-4EC0-A287-59908B48953F")]


### PR DESCRIPTION
Workaround of URL spoofing for this program. I think it's intended change to block this bulk downloader.

Before:
<img width="602" alt="Bag" src="https://user-images.githubusercontent.com/27248144/141393824-4426d919-de11-412b-89ba-8d7c6ee35279.png">

After:
<img width="408" alt="Good" src="https://user-images.githubusercontent.com/27248144/141393850-f3062c97-ba4a-4ffa-8d7c-543ce8c76486.png">

<img width="960" alt="Good 2" src="https://user-images.githubusercontent.com/27248144/141393860-04fc2337-3958-4baf-857c-a69927914498.png">

