### PR TITLE
Correctly handle Bandcamp antispam mechanism

### DIFF
--- a/src/BandcampDownloader/Bandcamp/Download/DownloadManager.cs
+++ b/src/BandcampDownloader/Bandcamp/Download/DownloadManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using BandcampDownloader.Audio;
@@ -293,7 +294,7 @@ internal sealed class DownloadManager : IDownloadManager
                 trackDownloaded = true;
                 DownloadProgressChanged?.Invoke(this, new DownloadProgressChangedArgs($"Downloaded track \"{track.Title}\" from url: {track.Mp3Url}", DownloadProgressChangedLevel.VerboseInfo));
             }
-            catch (WebException ex) // TODO is this still a WebException?
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
             {
                 // Connection closed probably because no response from Bandcamp
                 _logger.Error(ex);
@@ -378,7 +379,7 @@ internal sealed class DownloadManager : IDownloadManager
                 artwork = await artworkStream.ToArrayAsync(cancellationToken).ConfigureAwait(false);
                 artworkDownloaded = true;
             }
-            catch (WebException ex) // TODO is this still a WebException?
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
             {
                 // Connection closed probably because no response from Bandcamp
                 _logger.Error(ex);


### PR DESCRIPTION
Fixes part of #344 where logs indicates:

```
2025-12-01 11:29:22.2294  INFO   BandcampDownloader.UI.Dialogs.WindowMain  Retrieving album data for https://visionofgodrecords.bandcamp.com/album/utter-kaos-and-the-eclipsed-moon  
2025-12-01 11:29:22.2294  DEBUG  BandcampDownloader.UI.Dialogs.WindowMain  Downloading album info from url: https://visionofgodrecords.bandcamp.com/album/utter-kaos-and-the-eclipsed-moon  
2025-12-01 11:29:22.4677  ERROR  BandcampDownloader.Bandcamp.Download.AlbumInfoRetriever  Error downloading album info from url: https://visionofgodrecords.bandcamp.com/album/utter-kaos-and-the-eclipsed-moon  System.Net.Http.HttpRequestException: Response status code does not indicate success: 429 (Too Many Requests).
   at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
   at System.Net.Http.HttpClient.GetStringAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
   at BandcampDownloader.Bandcamp.Download.AlbumInfoRetriever.GetAlbumsAsync(IReadOnlyCollection`1 albumsUrls, CancellationToken cancellationToken) in D:\GitHub\BandcampDownloader\src\BandcampDownloader\Bandcamp\Download\AlbumInfoRetriever.cs:line 47
```