### PR TITLE
Fix cannot download track with no release_date

### DIFF
--- a/src/BandcampDownloader/Bandcamp/Extraction/Dto/JsonAlbum.cs
+++ b/src/BandcampDownloader/Bandcamp/Extraction/Dto/JsonAlbum.cs
@@ -31,8 +31,8 @@ internal sealed class JsonAlbum
         // Some albums do not have a cover art
         var artworkUrl = ArtId == null ? null : URL_START + ArtId.ToString().PadLeft(10, '0') + URL_END;
 
-        // Singles might not have a release date  #144
-        var releaseDate = ReleaseDate ?? AlbumData.ReleaseDate;
+        // Albums might not have an "album_release_date", especially when they're composed of a single track
+        var releaseDate = ReleaseDate ?? AlbumData.ReleaseDate ?? AlbumData.PublishDate ?? new DateTime();
 
         var album = new Album(Artist, artworkUrl, releaseDate, AlbumData.AlbumTitle);
 

--- a/src/BandcampDownloader/Bandcamp/Extraction/Dto/JsonAlbumData.cs
+++ b/src/BandcampDownloader/Bandcamp/Extraction/Dto/JsonAlbumData.cs
@@ -9,5 +9,8 @@ internal sealed class JsonAlbumData
     public string AlbumTitle { get; set; }
 
     [JsonPropertyName("release_date")]
-    public DateTime ReleaseDate { get; set; }
+    public DateTime? ReleaseDate { get; set; }
+
+    [JsonPropertyName("publish_date")]
+    public DateTime? PublishDate { get; set; }
 }


### PR DESCRIPTION
Fixes part of #341 
Fixes #342 
Fixes https://github.com/Otiel/BandcampDownloader/issues/336#issuecomment-3596061772 from #336